### PR TITLE
Handle popup close error in Google auth

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,7 @@
 import { auth, provider } from './firebaseConfig';
 import {
   signInWithPopup,
+  signInWithRedirect,
   signOut as firebaseSignOut,
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
@@ -11,8 +12,17 @@ export const signInWithGoogle = async () => {
   try {
     const result = await signInWithPopup(auth, provider);
     return result.user;
-  } catch (error) {
+  } catch (error: any) {
     console.error('Google sign-in error', error);
+    if (error?.code === 'auth/popup-closed-by-user' || error?.code === 'auth/popup-blocked') {
+      try {
+        await signInWithRedirect(auth, provider);
+        return null;
+      } catch (redirectError) {
+        console.error('Google redirect sign-in error', redirectError);
+        throw redirectError;
+      }
+    }
     throw error;
   }
 };


### PR DESCRIPTION
## Summary
- fallback to `signInWithRedirect` when popup authentication fails

## Testing
- `bun test` *(fails: Cannot find module 'firebase-admin/app')*

------
https://chatgpt.com/codex/tasks/task_e_684b2af0ead4832981137c92f0abca50