### PR TITLE
Fix timestamp usage in firestore arrays

### DIFF
--- a/api/payments/capture.ts
+++ b/api/payments/capture.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import fetch from 'node-fetch';
 import { initializeApp, cert, getApps } from 'firebase-admin/app';
-import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { getFirestore, FieldValue, Timestamp } from 'firebase-admin/firestore';
 
 if (!getApps().length) {
   initializeApp({
@@ -100,7 +100,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         type: 'paypal',
         amount: amountCaptured,
         status: 'completed',
-        timestamp: FieldValue.serverTimestamp(),
+        timestamp: Timestamp.now(),
       });
     }
 
@@ -119,7 +119,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       uid: userId,
       type: 'paypal',
       amount: amountCaptured,
-      timestamp: FieldValue.serverTimestamp(),
+      timestamp: Timestamp.now(),
       description: 'Top-up via PayPal',
     });
 

--- a/api/payments/paypal.ts
+++ b/api/payments/paypal.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import fetch from 'node-fetch';
 import { initializeApp, cert, getApps } from 'firebase-admin/app';
-import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { getFirestore, FieldValue, Timestamp } from 'firebase-admin/firestore';
 
 // ✅ Firebase Admin SDK Init
 if (!getApps().length) {
@@ -91,7 +91,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             {
               type: 'paypal',
               amount: parseFloat(amount),
-              timestamp: FieldValue.serverTimestamp(),
+              timestamp: Timestamp.now(),
               status: 'pending',
             },
           ],

--- a/src/utils/firestoreService.ts
+++ b/src/utils/firestoreService.ts
@@ -7,7 +7,8 @@ import {
   collection,
   onSnapshot,
   query,
-  serverTimestamp
+  serverTimestamp,
+  Timestamp
 } from 'firebase/firestore';
 import { db } from '../firebaseConfig';
 
@@ -78,7 +79,7 @@ export const deductICBalance = async (uid: string, amount: number): Promise<void
   txs.unshift({
     type: 'redemption',
     amount: -amount,
-    timestamp: serverTimestamp()
+    timestamp: Timestamp.now()
   });
   await updateDoc(userRef, { icTransactions: txs });
 };
@@ -102,7 +103,7 @@ export const addICTransaction = async (
   txs.unshift({
     type,
     amount: isNegative ? -amount : amount,
-    timestamp: serverTimestamp()
+    timestamp: Timestamp.now()
   });
 
   await updateDoc(userRef, {


### PR DESCRIPTION
## Summary
- avoid using `serverTimestamp()` inside transaction arrays
- replace with `Timestamp.now()` in serverless API and firestore utilities

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b57e38efc83299aac6170e441c8a4