### PR TITLE
Resolve timestamp conflict

### DIFF
--- a/api/payments/capture.ts
+++ b/api/payments/capture.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import fetch from 'node-fetch';
 import { initializeApp, cert, getApps } from 'firebase-admin/app';
-import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { getFirestore, FieldValue, Timestamp } from 'firebase-admin/firestore';
 
 if (!getApps().length) {
   initializeApp({
@@ -100,7 +100,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         type: 'paypal',
         amount: amountCaptured,
         status: 'completed',
-        timestamp: FieldValue.serverTimestamp(),
+        timestamp: Timestamp.now(),
       });
     }
 
@@ -119,7 +119,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       uid: userId,
       type: 'paypal',
       amount: amountCaptured,
-      timestamp: FieldValue.serverTimestamp(),
+      timestamp: Timestamp.now(),
       description: 'Top-up via PayPal',
     });
 

--- a/api/payments/capture.ts
+++ b/api/payments/capture.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import fetch from 'node-fetch';
 import { initializeApp, cert, getApps } from 'firebase-admin/app';
-import { getFirestore, FieldValue, Timestamp } from 'firebase-admin/firestore';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
 
 if (!getApps().length) {
   initializeApp({

--- a/api/payments/paypal.ts
+++ b/api/payments/paypal.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import fetch from 'node-fetch';
 import { initializeApp, cert, getApps } from 'firebase-admin/app';
-import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { getFirestore, FieldValue, Timestamp } from 'firebase-admin/firestore';
 
 // ✅ Firebase Admin SDK Init
 if (!getApps().length) {
@@ -91,7 +91,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             {
               type: 'paypal',
               amount: parseFloat(amount),
-              timestamp: FieldValue.serverTimestamp(),
+              timestamp: Timestamp.now(),
               status: 'pending',
             },
           ],

--- a/api/payments/paypal.ts
+++ b/api/payments/paypal.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import fetch from 'node-fetch';
 import { initializeApp, cert, getApps } from 'firebase-admin/app';
-import { getFirestore, FieldValue, Timestamp } from 'firebase-admin/firestore';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
 
 // ✅ Firebase Admin SDK Init
 if (!getApps().length) {

--- a/src/pages/RedeemUmrah.tsx
+++ b/src/pages/RedeemUmrah.tsx
@@ -13,7 +13,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useUser } from "@/contexts/UserContext";
 import { submitUmrahRedemption } from '@/utils/firebase/redemptionService';
 import { sendConfirmationEmail } from '@/firestore';
-import { logActivity, getICBalance, deductICBalance } from '@/utils/firestoreService';
+import { logActivity, getICBalance, deductICBalance, incrementBalance } from '@/utils/firestoreService';
 import TierPackages from '@/components/umrah/TierPackages';
 import RedemptionForm from '@/components/umrah/RedemptionForm';
 
@@ -129,6 +129,13 @@ const RedeemUmrah = () => {
       navigate('/dashboard');
     } catch (error) {
       console.error("Error submitting redemption:", error);
+      if (user) {
+        try {
+          await incrementBalance(user.uid, TIER_PRICES[selectedTier] ?? 0);
+        } catch (refundErr) {
+          console.error("Error refunding balance:", refundErr);
+        }
+      }
       toast({
         title: "Error Submitting Redemption",
         description: "Please try again later.",

--- a/src/utils/firestoreService.ts
+++ b/src/utils/firestoreService.ts
@@ -7,7 +7,7 @@ import {
   collection,
   onSnapshot,
   query,
-  serverTimestamp
+  Timestamp
 } from 'firebase/firestore';
 import { db } from '../firebaseConfig';
 
@@ -67,20 +67,23 @@ export const deductICBalance = async (uid: string, amount: number): Promise<void
   const userRef = doc(db, 'users', uid);
   const userSnap = await getDoc(userRef);
   if (!userSnap.exists()) throw new Error('User not found');
-  const currentBalance = userSnap.data().icBalance ?? userSnap.data().balance ?? 0;
+
+  const userData = userSnap.data();
+  const currentBalance = userData.icBalance ?? userData.balance ?? 0;
   if (amount > currentBalance) throw new Error('Insufficient balance');
 
-  await updateDoc(userRef, {
-    icBalance: currentBalance - amount
-  });
-
-  const txs = userSnap.data().icTransactions || [];
+  const newBalance = currentBalance - amount;
+  const txs = userData.icTransactions || [];
   txs.unshift({
     type: 'redemption',
     amount: -amount,
-    timestamp: serverTimestamp()
+    timestamp: Timestamp.now(),
   });
-  await updateDoc(userRef, { icTransactions: txs });
+
+  await updateDoc(userRef, {
+    icBalance: newBalance,
+    icTransactions: txs,
+  });
 };
 
 // ✅ Add Custom IC Transaction
@@ -102,7 +105,7 @@ export const addICTransaction = async (
   txs.unshift({
     type,
     amount: isNegative ? -amount : amount,
-    timestamp: serverTimestamp()
+    timestamp: Timestamp.now()
   });
 
   await updateDoc(userRef, {


### PR DESCRIPTION
## Summary
- ensure IC deduction updates balance and transactions together
- refund tokens when a redemption fails
- standardize use of `Timestamp.now()` for PayPal logs
- drop unused `serverTimestamp` import

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684b57e38efc83299aac6170e441c8a4