### PR TITLE
Resolve timestamp conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This project is built with:
 - 🕋 Redeem IC for Umrah deposits or good deeds
 - 📈 Admin dashboard for redemptions, top-ups, and activity logs
 - 🧾 Activity-based spiritual impact tracking
+- 🔄 Firestore transactions use `Timestamp.now()` to avoid invalid server timestamps in arrays
 - 🔁 Daily check-in rewards
 - 💬 Planned AI agent integration (Flowise-ready)
 

--- a/api/payments/capture.ts
+++ b/api/payments/capture.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import fetch from 'node-fetch';
 import { initializeApp, cert, getApps } from 'firebase-admin/app';
-import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
 
 if (!getApps().length) {
   initializeApp({
@@ -100,7 +100,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         type: 'paypal',
         amount: amountCaptured,
         status: 'completed',
-        timestamp: FieldValue.serverTimestamp(),
+        timestamp: Timestamp.now(),
       });
     }
 
@@ -119,7 +119,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       uid: userId,
       type: 'paypal',
       amount: amountCaptured,
-      timestamp: FieldValue.serverTimestamp(),
+      timestamp: Timestamp.now(),
       description: 'Top-up via PayPal',
     });
 

--- a/api/payments/paypal.ts
+++ b/api/payments/paypal.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import fetch from 'node-fetch';
 import { initializeApp, cert, getApps } from 'firebase-admin/app';
-import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
 
 // ✅ Firebase Admin SDK Init
 if (!getApps().length) {
@@ -91,7 +91,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             {
               type: 'paypal',
               amount: parseFloat(amount),
-              timestamp: FieldValue.serverTimestamp(),
+              timestamp: Timestamp.now(),
               status: 'pending',
             },
           ],

--- a/src/components/DailyCheckIn.tsx
+++ b/src/components/DailyCheckIn.tsx
@@ -8,7 +8,6 @@ import {
   collection,
   addDoc,
   Timestamp,
-  serverTimestamp,
 } from 'firebase/firestore';
 import { useToast } from '@/hooks/use-toast';
 import { Button } from '@/components/ui/button';
@@ -68,7 +67,7 @@ const DailyCheckIn = () => {
     // Update balance and metadata
     await updateDoc(userRef, {
       icBalance: currentBalance + 1,
-      lastCheckIn: serverTimestamp(),
+      lastCheckIn: Timestamp.now(),
       checkInStreak: newStreak,
     });
 
@@ -77,7 +76,7 @@ const DailyCheckIn = () => {
       uid: user.uid,
       type: 'daily_checkin',
       amount: 1,
-      timestamp: serverTimestamp(),
+      timestamp: Timestamp.now(),
       description: 'Daily Check-In Reward',
     });
 

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState, useEffect } from 'react';
 import { auth, db, storage } from "@/firebaseConfig";
-import { doc, getDoc, setDoc, serverTimestamp } from 'firebase/firestore';
+import { doc, getDoc, setDoc, Timestamp } from 'firebase/firestore';
 import { onAuthStateChanged, User } from 'firebase/auth';
 
 type UserMode = 'web2' | 'web3';
@@ -95,7 +95,7 @@ export const UserProvider: React.FC<UserProviderProps> = ({ children }) => {
         uid: user.uid,
         email: user.email,
         displayName: user.displayName,
-        createdAt: serverTimestamp(),
+        createdAt: Timestamp.now(),
         onboarded: false,
         mode: 'web2' as UserMode,
         balance: 0,

--- a/src/firestore.ts
+++ b/src/firestore.ts
@@ -1,6 +1,6 @@
 
 import { db } from './firebaseConfig';
-import { collection, addDoc, getDocs, query, where, serverTimestamp } from "firebase/firestore";
+import { collection, addDoc, getDocs, query, where, Timestamp } from "firebase/firestore";
 
 export async function logRedemption(data: any) {
   await addDoc(collection(db, "redemptions"), data);
@@ -42,7 +42,7 @@ export async function sendConfirmationEmail(data: {
       responseTime: "48 hours",
       hasPassport: data.fileURL ? true : false
     },
-    timestamp: serverTimestamp()
+    timestamp: Timestamp.now()
   });
   
   return true;

--- a/src/pages/RedeemUmrah.tsx
+++ b/src/pages/RedeemUmrah.tsx
@@ -13,7 +13,7 @@ import { useToast } from '@/hooks/use-toast';
 import { useUser } from "@/contexts/UserContext";
 import { submitUmrahRedemption } from '@/utils/firebase/redemptionService';
 import { sendConfirmationEmail } from '@/firestore';
-import { logActivity, getICBalance, deductICBalance } from '@/utils/firestoreService';
+import { logActivity, getICBalance, deductICBalance, incrementBalance } from '@/utils/firestoreService';
 import TierPackages from '@/components/umrah/TierPackages';
 import RedemptionForm from '@/components/umrah/RedemptionForm';
 
@@ -129,6 +129,13 @@ const RedeemUmrah = () => {
       navigate('/dashboard');
     } catch (error) {
       console.error("Error submitting redemption:", error);
+      if (user) {
+        try {
+          await incrementBalance(user.uid, TIER_PRICES[selectedTier] ?? 0);
+        } catch (refundErr) {
+          console.error("Error refunding balance:", refundErr);
+        }
+      }
       toast({
         title: "Error Submitting Redemption",
         description: "Please try again later.",

--- a/src/services/activityService.ts
+++ b/src/services/activityService.ts
@@ -1,6 +1,6 @@
 
 import { db } from '@/firebaseConfig';
-import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
+import { collection, addDoc, Timestamp } from 'firebase/firestore';
 
 type ActivityType = 'redemption' | 'donation' | 'reward' | 'purchase' | 'card_load';
 
@@ -15,7 +15,7 @@ export const logActivity = async (data: ActivityLogData): Promise<void> => {
   try {
     await addDoc(collection(db, 'activity_logs'), {
       ...data,
-      timestamp: serverTimestamp()
+      timestamp: Timestamp.now()
     });
   } catch (error) {
     console.error("Error logging activity:", error);

--- a/src/utils/firebase/activityService.ts
+++ b/src/utils/firebase/activityService.ts
@@ -1,10 +1,10 @@
 
 import { db } from '@/firebaseConfig';
-import { 
-  collection, 
-  addDoc, 
-  serverTimestamp, 
-  query, 
+import {
+  collection,
+  addDoc,
+  Timestamp,
+  query,
   where, 
   orderBy, 
   limit,
@@ -26,7 +26,7 @@ export const logActivity = async (data: ActivityLog): Promise<void> => {
   try {
     await addDoc(collection(db, 'activity_logs'), {
       ...data,
-      timestamp: data.timestamp || serverTimestamp()
+      timestamp: data.timestamp || Timestamp.now()
     });
   } catch (error) {
     console.error("Error logging activity:", error);
@@ -67,7 +67,7 @@ export const logAdminAction = async (adminUid: string, action: string, details: 
       adminUid,
       action,
       details,
-      timestamp: serverTimestamp()
+      timestamp: Timestamp.now()
     });
   } catch (error) {
     console.error("Error logging admin action:", error);

--- a/src/utils/firebase/redemptionService.ts
+++ b/src/utils/firebase/redemptionService.ts
@@ -8,9 +8,8 @@ import {
   updateDoc, 
   query, 
   where, 
-  serverTimestamp, 
-  orderBy,
   Timestamp,
+  orderBy,
   limit
 } from 'firebase/firestore';
 
@@ -41,7 +40,7 @@ export const submitUmrahRedemption = async (data: Omit<UmrahRedemptionData, 'sta
   const submissionData = {
     ...data,
     status: 'pending' as const,
-    createdAt: serverTimestamp()
+    createdAt: Timestamp.now()
   };
   
   // Create document with user ID path
@@ -117,7 +116,7 @@ export const updateRedemptionStatus = async (
   
   if (adminData) {
     updateData.reviewedBy = adminData.adminId;
-    updateData.reviewedAt = serverTimestamp();
+    updateData.reviewedAt = Timestamp.now();
     
     if (adminData.notes) {
       updateData.adminNotes = adminData.notes;

--- a/src/utils/firestoreService.ts
+++ b/src/utils/firestoreService.ts
@@ -7,7 +7,7 @@ import {
   collection,
   onSnapshot,
   query,
-  serverTimestamp
+  Timestamp
 } from 'firebase/firestore';
 import { db } from '../firebaseConfig';
 
@@ -67,20 +67,23 @@ export const deductICBalance = async (uid: string, amount: number): Promise<void
   const userRef = doc(db, 'users', uid);
   const userSnap = await getDoc(userRef);
   if (!userSnap.exists()) throw new Error('User not found');
-  const currentBalance = userSnap.data().icBalance ?? userSnap.data().balance ?? 0;
+
+  const userData = userSnap.data();
+  const currentBalance = userData.icBalance ?? userData.balance ?? 0;
   if (amount > currentBalance) throw new Error('Insufficient balance');
 
-  await updateDoc(userRef, {
-    icBalance: currentBalance - amount
-  });
-
-  const txs = userSnap.data().icTransactions || [];
+  const newBalance = currentBalance - amount;
+  const txs = userData.icTransactions || [];
   txs.unshift({
     type: 'redemption',
     amount: -amount,
-    timestamp: serverTimestamp()
+    timestamp: Timestamp.now(),
   });
-  await updateDoc(userRef, { icTransactions: txs });
+
+  await updateDoc(userRef, {
+    icBalance: newBalance,
+    icTransactions: txs,
+  });
 };
 
 // ✅ Add Custom IC Transaction
@@ -102,7 +105,7 @@ export const addICTransaction = async (
   txs.unshift({
     type,
     amount: isNegative ? -amount : amount,
-    timestamp: serverTimestamp()
+    timestamp: Timestamp.now()
   });
 
   await updateDoc(userRef, {


### PR DESCRIPTION
## Summary
- ensure IC deduction updates balance and transactions together
- refund tokens when a redemption fails
- standardize use of `Timestamp.now()` for PayPal logs
- drop unused `serverTimestamp` import
- remove unused FieldValue imports
- note Timestamp usage in README
- remove serverTimestamp in favor of `Timestamp.now`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684b57e38efc83299aac6170e441c8a4